### PR TITLE
アイテム更新機能(PATCH /items/{id})の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ curl -X GET http://localhost:8080/items/summary
 }
 ```
 
+#### 6. アイテムの更新 (PATCH)
+```bash
+curl -X PATCH http://localhost:8080/items/1 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "エルメス バーキン",
+    "brand": "HERMÈS",
+    "purchase_price": 3000000,
+  }'
+```
+
+
 ### エラーレスポンス形式
 
 ```json

--- a/internal/infrastructure/server/server.go
+++ b/internal/infrastructure/server/server.go
@@ -53,6 +53,7 @@ func (s *Server) Run(ctx context.Context) error {
 		itemsGroup.GET("", itemHandler.GetItems)           // GET /items
 		itemsGroup.POST("", itemHandler.CreateItem)        // POST /items
 		itemsGroup.GET("/:id", itemHandler.GetItem)        // GET /items/{id}
+		itemsGroup.PATCH("/:id", itemHandler.UpdateItem)   // PATCH /items/{id}
 		itemsGroup.DELETE("/:id", itemHandler.DeleteItem)  // DELETE /items/{id}
 		itemsGroup.GET("/summary", itemHandler.GetSummary) // GET /items/summary (bonus)
 	}

--- a/internal/interfaces/controller/items/items_controller.go
+++ b/internal/interfaces/controller/items/items_controller.go
@@ -10,6 +10,44 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+func (h *ItemHandler) UpdateItem(c echo.Context) error {
+	// UpdateItem - PATCHリクエストを処理してアイテムを更新する
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: "invalid item ID",
+		})
+	}
+
+	var input usecase.UpdateItemInput
+	if err := c.Bind(&input); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: "invalid request format",
+		})
+	}
+
+	item, err := h.itemUsecase.UpdateItem(c.Request().Context(), id, input)
+	if err != nil {
+		if domainErrors.IsNotFoundError(err) {
+			return c.JSON(http.StatusNotFound, ErrorResponse{
+				Error: "item not found",
+			})
+		}
+		if domainErrors.IsValidationError(err) {
+			return c.JSON(http.StatusBadRequest, ErrorResponse{
+				Error:   "validation failed",
+				Details: []string{err.Error()},
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: "failed to update item",
+		})
+	}
+
+	return c.JSON(http.StatusOK, item)
+}
+
 type ItemHandler struct {
 	itemUsecase usecase.ItemUsecase
 }

--- a/internal/interfaces/database/items_repository.go
+++ b/internal/interfaces/database/items_repository.go
@@ -166,7 +166,7 @@ func scanItem(scanner interface {
 	Scan(dest ...interface{}) error
 }) (*entity.Item, error) {
 	var item entity.Item
-	var purchaseDate string
+	var purchaseDate time.Time
 	var createdAt, updatedAt time.Time
 
 	err := scanner.Scan(
@@ -175,7 +175,7 @@ func scanItem(scanner interface {
 		&item.Category,
 		&item.Brand,
 		&item.PurchasePrice,
-		&purchaseDate,
+		&purchaseDate, // time.Time型の変数へスキャン
 		&createdAt,
 		&updatedAt,
 	)
@@ -183,14 +183,8 @@ func scanItem(scanner interface {
 		return nil, err
 	}
 
-	if purchaseDate != "" {
-		if parsedDate, err := time.Parse("2006-01-02", purchaseDate); err == nil {
-			item.PurchaseDate = parsedDate.Format("2006-01-02")
-		} else {
-			item.PurchaseDate = purchaseDate
-		}
-	}
-
+	// データベースから読み込んだ値を "YYYY-MM-DD" 形式にフォーマットする
+	item.PurchaseDate = purchaseDate.Format("2006-01-02")
 	item.CreatedAt = createdAt
 	item.UpdatedAt = updatedAt
 

--- a/internal/interfaces/database/items_repository.go
+++ b/internal/interfaces/database/items_repository.go
@@ -14,6 +14,30 @@ type ItemRepository struct {
 	SqlHandler
 }
 
+func (r *ItemRepository) Update(ctx context.Context, item *entity.Item) (*entity.Item, error) {
+	// Update - アイテムを更新する
+	// 変更対象は: `name`, `brand`, `purchase_price`
+	query := `
+		UPDATE items
+		SET name = ?, category = ?, brand = ?, purchase_price = ?, purchase_date = ?, updated_at = ?
+		WHERE id = ?
+	`
+	_, err := r.Execute(ctx, query,
+		item.Name,
+		item.Category,
+		item.Brand,
+		item.PurchasePrice,
+		item.PurchaseDate,
+		item.UpdatedAt,
+		item.ID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", domainErrors.ErrDatabaseError, err.Error())
+	}
+
+	return r.FindByID(ctx, item.ID)
+}
+
 func (r *ItemRepository) FindAll(ctx context.Context) ([]*entity.Item, error) {
 	query := `
         SELECT id, name, category, brand, purchase_price, purchase_date, created_at, updated_at

--- a/internal/usecase/repository.go
+++ b/internal/usecase/repository.go
@@ -17,6 +17,9 @@ type ItemRepository interface {
 	// Create creates a new item and returns it with the generated ID
 	Create(ctx context.Context, item *entity.Item) (*entity.Item, error)
 
+	// Update updates an existing item
+	Update(ctx context.Context, item *entity.Item) (*entity.Item, error)
+
 	// Delete deletes an item by ID
 	Delete(ctx context.Context, id int64) error
 

--- a/internal/usecase/service.go
+++ b/internal/usecase/service.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"Aicon-assignment/internal/domain/entity"
 	domainErrors "Aicon-assignment/internal/domain/errors"
@@ -12,6 +13,7 @@ type ItemUsecase interface {
 	GetAllItems(ctx context.Context) ([]*entity.Item, error)
 	GetItemByID(ctx context.Context, id int64) (*entity.Item, error)
 	CreateItem(ctx context.Context, input CreateItemInput) (*entity.Item, error)
+	UpdateItem(ctx context.Context, id int64, input UpdateItemInput) (*entity.Item, error)
 	DeleteItem(ctx context.Context, id int64) error
 	GetCategorySummary(ctx context.Context) (*CategorySummary, error)
 }
@@ -22,6 +24,14 @@ type CreateItemInput struct {
 	Brand         string `json:"brand"`
 	PurchasePrice int    `json:"purchase_price"`
 	PurchaseDate  string `json:"purchase_date"`
+}
+
+// UpdateItemInput - PATCH request 用構造体
+// ポインタ型を使い、リクエストに含まれるフィールドのみを更新対象とする
+type UpdateItemInput struct {
+	Name          *string `json:"name,omitempty"`
+	Brand         *string `json:"brand,omitempty"`
+	PurchasePrice *int    `json:"purchase_price,omitempty"`
 }
 
 type CategorySummary struct {
@@ -37,6 +47,55 @@ func NewItemUsecase(itemRepo ItemRepository) ItemUsecase {
 	return &itemUsecase{
 		itemRepo: itemRepo,
 	}
+}
+
+func (u *itemUsecase) UpdateItem(ctx context.Context, id int64, input UpdateItemInput) (*entity.Item, error) {
+	// UpdateItem - 指定されたIDのアイテムを部分的に更新する (`UpdateItemInput`を参照)
+	if id <= 0 {
+		return nil, domainErrors.ErrInvalidInput
+	}
+
+	// 既存のアイテムを取得
+	item, err := u.itemRepo.FindByID(ctx, id)
+	if err != nil {
+		if domainErrors.IsNotFoundError(err) {
+			return nil, domainErrors.ErrItemNotFound
+		}
+		return nil, fmt.Errorf("failed to retrieve item for update: %w", err)
+	}
+
+	// 更新はリクエストされたフィールドのみ
+	isUpdated := false
+	if input.Name != nil {
+		item.Name = strings.TrimSpace(*input.Name)
+		isUpdated = true
+	}
+	if input.Brand != nil {
+		item.Brand = strings.TrimSpace(*input.Brand)
+		isUpdated = true
+	}
+	if input.PurchasePrice != nil {
+		item.PurchasePrice = *input.PurchasePrice
+		isUpdated = true
+	}
+
+	// 何も更新されていない場合, 検証やDB更新をスキップ
+	if !isUpdated {
+		return item, nil
+	}
+
+	// 更新後の状態で検証を実行
+	if err := item.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", domainErrors.ErrInvalidInput, err.Error())
+	}
+
+	// データベースを更新
+	updatedItem, err := u.itemRepo.Update(ctx, item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update item: %w", err)
+	}
+
+	return updatedItem, nil
 }
 
 func (u *itemUsecase) GetAllItems(ctx context.Context) ([]*entity.Item, error) {

--- a/internal/usecase/service_test.go
+++ b/internal/usecase/service_test.go
@@ -76,6 +76,33 @@ func TestItemUsecase_UpdateItem(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "正常系: 更新対象外のフィールドは変更されない",
+			id:   1,
+			input: UpdateItemInput{
+				Name: stringp("新しい名前"), // nameだけ更新リクエスト
+			},
+			setupMock: func(mockRepo *MockItemRepository) {
+				// 1. FindByIDで元のアイテムを返す
+				originalItem, _ := entity.NewItem("古い名前", "時計", "ROLEX", 1000000, "2023-01-01")
+				originalItem.ID = 1
+				mockRepo.On("FindByID", mock.Anything, int64(1)).Return(originalItem, nil).Once()
+
+				// 2. Updateメソッドが呼ばれることを検証。
+				//    このとき渡されるItemオブジェクトのcategoryが元の"時計"のままであることを確認する
+				mockRepo.On("Update", mock.Anything, mock.MatchedBy(func(item *entity.Item) bool {
+					// 名前が更新され、カテゴリは元のままであることをassert
+					assert.Equal(t, "新しい名前", item.Name)
+					assert.Equal(t, "時計", item.Category)             // categoryは変更されていない
+					assert.Equal(t, "2023-01-01", item.PurchaseDate) // purchase_dateも変更されていない
+					return true
+				})).Return(func(ctx context.Context, item *entity.Item) *entity.Item {
+					// Updateに渡されたitemをそのまま返すシミュレーション
+					return item
+				}, nil).Once()
+			},
+			expectError: false,
+		},
+		{
 			name:  "正常系: 更新フィールドなし",
 			id:    1,
 			input: UpdateItemInput{},

--- a/internal/usecase/service_test.go
+++ b/internal/usecase/service_test.go
@@ -12,6 +12,157 @@ import (
 	domainErrors "Aicon-assignment/internal/domain/errors"
 )
 
+// Utility function to create a pointer to a string
+func stringp(s string) *string {
+	return &s
+}
+
+// Utility function to create a pointer to an int
+func intp(i int) *int {
+	return &i
+}
+
+func (m *MockItemRepository) Update(ctx context.Context, item *entity.Item) (*entity.Item, error) {
+	args := m.Called(ctx, item)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entity.Item), args.Error(1)
+}
+
+func TestItemUsecase_UpdateItem(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          int64
+		input       UpdateItemInput
+		setupMock   func(*MockItemRepository)
+		expectError bool
+		expectedErr error
+	}{
+		{
+			name: "正常系: 名前のみ更新",
+			id:   1,
+			input: UpdateItemInput{
+				Name: stringp("新しい時計"),
+			},
+			setupMock: func(mockRepo *MockItemRepository) {
+				originalItem, _ := entity.NewItem("古い時計", "時計", "ROLEX", 1000000, "2023-01-01")
+				originalItem.ID = 1
+				mockRepo.On("FindByID", mock.Anything, int64(1)).Return(originalItem, nil).Once()
+
+				updatedItem, _ := entity.NewItem("新しい時計", "時計", "ROLEX", 1000000, "2023-01-01")
+				updatedItem.ID = 1
+				mockRepo.On("Update", mock.Anything, mock.AnythingOfType("*entity.Item")).Return(updatedItem, nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name: "正常系: 全てのフィールドを更新",
+			id:   1,
+			input: UpdateItemInput{
+				Name:          stringp("新しい時計"),
+				Brand:         stringp("NEW BRAND"),
+				PurchasePrice: intp(2000000),
+			},
+			setupMock: func(mockRepo *MockItemRepository) {
+				originalItem, _ := entity.NewItem("古い時計", "時計", "ROLEX", 1000000, "2023-01-01")
+				originalItem.ID = 1
+				mockRepo.On("FindByID", mock.Anything, int64(1)).Return(originalItem, nil).Once()
+
+				updatedItem, _ := entity.NewItem("新しい時計", "時計", "NEW BRAND", 2000000, "2023-01-01")
+				updatedItem.ID = 1
+				mockRepo.On("Update", mock.Anything, mock.AnythingOfType("*entity.Item")).Return(updatedItem, nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:  "正常系: 更新フィールドなし",
+			id:    1,
+			input: UpdateItemInput{},
+			setupMock: func(mockRepo *MockItemRepository) {
+				originalItem, _ := entity.NewItem("古い時計", "時計", "ROLEX", 1000000, "2023-01-01")
+				originalItem.ID = 1
+				mockRepo.On("FindByID", mock.Anything, int64(1)).Return(originalItem, nil).Once()
+				// Update should not be called
+			},
+			expectError: false,
+		},
+		{
+			name: "異常系: 存在しないID",
+			id:   999,
+			input: UpdateItemInput{
+				Name: stringp("新しい時計"),
+			},
+			setupMock: func(mockRepo *MockItemRepository) {
+				mockRepo.On("FindByID", mock.Anything, int64(999)).Return((*entity.Item)(nil), domainErrors.ErrItemNotFound).Once()
+			},
+			expectError: true,
+			expectedErr: domainErrors.ErrItemNotFound,
+		},
+		{
+			name: "異常系: 無効な入力（名前が空）",
+			id:   1,
+			input: UpdateItemInput{
+				Name: stringp(""),
+			},
+			setupMock: func(mockRepo *MockItemRepository) {
+				originalItem, _ := entity.NewItem("古い時計", "時計", "ROLEX", 1000000, "2023-01-01")
+				originalItem.ID = 1
+				mockRepo.On("FindByID", mock.Anything, int64(1)).Return(originalItem, nil).Once()
+			},
+			expectError: true,
+			expectedErr: domainErrors.ErrInvalidInput,
+		},
+		{
+			name: "異常系: Updateでデータベースエラー",
+			id:   1,
+			input: UpdateItemInput{
+				Name: stringp("新しい時計"),
+			},
+			setupMock: func(mockRepo *MockItemRepository) {
+				originalItem, _ := entity.NewItem("古い時計", "時計", "ROLEX", 1000000, "2023-01-01")
+				originalItem.ID = 1
+				mockRepo.On("FindByID", mock.Anything, int64(1)).Return(originalItem, nil).Once()
+				mockRepo.On("Update", mock.Anything, mock.AnythingOfType("*entity.Item")).Return((*entity.Item)(nil), domainErrors.ErrDatabaseError).Once()
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := new(MockItemRepository)
+			tt.setupMock(mockRepo)
+			usecase := NewItemUsecase(mockRepo)
+
+			ctx := context.Background()
+			item, err := usecase.UpdateItem(ctx, tt.id, tt.input)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+				assert.Nil(t, item)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, item)
+				if tt.input.Name != nil {
+					assert.Equal(t, *tt.input.Name, item.Name)
+				}
+				if tt.input.Brand != nil {
+					assert.Equal(t, *tt.input.Brand, item.Brand)
+				}
+				if tt.input.PurchasePrice != nil {
+					assert.Equal(t, *tt.input.PurchasePrice, item.PurchasePrice)
+				}
+			}
+
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
 // MockItemRepository はtestify/mockを使用したモックリポジトリ
 type MockItemRepository struct {
 	mock.Mock


### PR DESCRIPTION
### 概要
アイテム情報の一部（name, brand, purchase_price）を更新するための PATCH /items/{id} エンドポイントを実装

### 関連Issue
Closes #1

### 懸念 (バグ?修正)
`items_repository.go` の scanItem 関数を修正し、purchase_date が常に YYYY-MM-DD 形式で扱われるようにしました。これにより、更新時のバリデーションエラーを解消しましたが、他のプロセスで影響するかもしれません。
- バグについてのIssue → #3 
(検証したかったのですが、じかんが足りず :pray:)

